### PR TITLE
update rnnoise_create signature

### DIFF
--- a/rnnoise.py
+++ b/rnnoise.py
@@ -9,12 +9,13 @@ if (not("/" in lib_path)):
 lib = ctypes.cdll.LoadLibrary(lib_path)
 lib.rnnoise_process_frame.argtypes = [ctypes.c_void_p,ctypes.POINTER(ctypes.c_float),ctypes.POINTER(ctypes.c_float)]
 lib.rnnoise_process_frame.restype = ctypes.c_float
+lib.rnnoise_create.argtypes = [ctypes.c_void_p]
 lib.rnnoise_create.restype = ctypes.c_void_p
 lib.rnnoise_destroy.argtypes = [ctypes.c_void_p]
 
 class RNNoise(object):
 	def __init__(self):
-		self.obj = lib.rnnoise_create()
+		self.obj = lib.rnnoise_create(None)
 	def process_frame(self,inbuf):
 		outbuf = numpy.ndarray((480,), 'h', inbuf).astype(ctypes.c_float)
 		outbuf_ptr = outbuf.ctypes.data_as(ctypes.POINTER(ctypes.c_float))


### PR DESCRIPTION
`rnnoise_create` requires a parameter since https://github.com/xiph/rnnoise/commit/231b9c02d14a74cb449a98004cb7a2cf1bdeca2f. The parameter denotes the model to use; NULL can be used as default.

If this parameter is not added, mysterious segfaults occur: https://github.com/xiph/rnnoise/issues/69#issuecomment-498477189

Example:
```
0x00007fffec1308de in compute_dense (layer=0x0, output=output@entry=0x7fffffff3c90, input=input@entry=0x7fffffff4cd0) at src/rnn.c:85
```